### PR TITLE
#### - Add WhenNotEmpty extension method

### DIFF
--- a/src/Extensions.IntegrationTests/Validation/WhenNotNullExtensionMethodTestFixture.cs
+++ b/src/Extensions.IntegrationTests/Validation/WhenNotNullExtensionMethodTestFixture.cs
@@ -1,0 +1,28 @@
+using NUnit;
+using NUnit.Framework;
+using Shouldly;
+using System;
+
+namespace AsIfByMagic.Extensions.Validation
+{
+    [TestFixture]
+    public class WhenNotNullExtensionMethodTestFixture
+    {
+        public class Service
+        {
+            private Dependency Dependency { get; }
+            public Service(Dependency dependency)
+            {
+                Dependency = dependency.WhenNotNull(nameof(dependency));
+            }
+        }
+
+        public class Dependency { }
+
+        [Test]
+        public void WhenNotNull_Given_ParamName_Then_ExceptionThrownWithParamName()
+        {
+            Should.Throw<ArgumentNullException>(() => new Service(null)).ParamName.ShouldBe("dependency");
+        }
+    }
+}

--- a/src/Extensions.UnitTests/Validation/WhenNotEmptyExtensionMethodTestFixture.cs
+++ b/src/Extensions.UnitTests/Validation/WhenNotEmptyExtensionMethodTestFixture.cs
@@ -1,0 +1,31 @@
+using NUnit.Framework;
+using Shouldly;
+using System;
+
+namespace AsIfByMagic.Extensions.Validation
+{
+    [TestFixture]
+    public class WhenNotEmptyExtensionMethodTestFixture
+    {
+        [Test]
+        public void WhenNotEmpty_Given_ValueIsNull_Then_ExceptionThrown()
+        {
+            Should.Throw<ArgumentNullException>(() => ((string)null).WhenNotEmpty("parameter")).ParamName.ShouldBe("parameter");
+        }
+
+        [Test]
+        public void WhenNotEmpty_Given_ValueIsEmpty_Then_ExceptionThrown()
+        {
+            var thrown = Should.Throw<ArgumentException>(() => string.Empty.WhenNotEmpty("parameter"));
+
+            thrown.Message.ShouldStartWith("Value cannot be an empty string.");
+            thrown.ParamName.ShouldBe("parameter");
+        }
+
+        [Test]
+        public void WhenNotEmpty_Given_ValueIsNotNullOrEmpty_Then_Value()
+        {
+            "value".WhenNotEmpty("parameter").ShouldBe("value");
+        }
+    }
+}

--- a/src/Extensions.UnitTests/Validation/WhenNotEmptyExtensionMethodTestFixture.cs
+++ b/src/Extensions.UnitTests/Validation/WhenNotEmptyExtensionMethodTestFixture.cs
@@ -8,13 +8,13 @@ namespace AsIfByMagic.Extensions.Validation
     public class WhenNotEmptyExtensionMethodTestFixture
     {
         [Test]
-        public void WhenNotEmpty_Given_ValueIsNull_Then_ExceptionThrown()
+        public void WhenNotEmpty_String_Given_ValueIsNull_Then_ExceptionThrown()
         {
             Should.Throw<ArgumentNullException>(() => ((string)null).WhenNotEmpty("parameter")).ParamName.ShouldBe("parameter");
         }
 
         [Test]
-        public void WhenNotEmpty_Given_ValueIsEmpty_Then_ExceptionThrown()
+        public void WhenNotEmpty_String_Given_ValueIsEmpty_Then_ExceptionThrown()
         {
             var thrown = Should.Throw<ArgumentException>(() => string.Empty.WhenNotEmpty("parameter"));
 
@@ -23,9 +23,37 @@ namespace AsIfByMagic.Extensions.Validation
         }
 
         [Test]
-        public void WhenNotEmpty_Given_ValueIsNotNullOrEmpty_Then_Value()
+        public void WhenNotEmpty_String_Given_ValueIsNotNullOrEmpty_Then_Value()
         {
             "value".WhenNotEmpty("parameter").ShouldBe("value");
+        }
+
+        [Test]
+        public void WhenNotEmpty_Enumerable_Given_ValueIsNull_Then_ExceptionThrown()
+        {
+            Should.Throw<ArgumentNullException>(() => ((string[])null).WhenNotEmpty("nullArray")).ParamName.ShouldBe("value");
+        }
+
+        [Test]
+        public void WhenNotEmpty_Enumerable_Given_EmptyEnumerable_Then_ExceptionThrown()
+        {
+            var thrown = Should.Throw<ArgumentException>(() => new string[]{}.WhenNotEmpty("emptyArray"));
+
+            thrown.Message.ShouldStartWith("Value cannot be an empty enumerable.");
+            thrown.ParamName.ShouldBe("emptyArray");
+        }
+
+        [Test]
+        public void WhenNotEmpty_Enumerable_GivenNotEmptyEnumerable_Then_Value()
+        {
+            // Arrange
+            var value = new[]{"These", "Are", "Some", "Strings"};
+
+            // Act
+            var actual = value.WhenNotEmpty("array");
+
+            // Assert
+            actual.ShouldBeSameAs(value);
         }
     }
 }

--- a/src/Extensions.UnitTests/Validation/WhenNotEmptyExtensionMethodTestFixture.cs
+++ b/src/Extensions.UnitTests/Validation/WhenNotEmptyExtensionMethodTestFixture.cs
@@ -55,5 +55,27 @@ namespace AsIfByMagic.Extensions.Validation
             // Assert
             actual.ShouldBeSameAs(value);
         }
+
+        [Test]
+        public void WhenNotEmpty_Guid_GivenEmptyGuid_Then_ExceptionThrown()
+        {
+            var thrown = Should.Throw<ArgumentException>(() => Guid.Empty.WhenNotEmpty("parameter"));
+
+            thrown.Message.ShouldStartWith("Value cannot be an empty guid.");
+            thrown.ParamName.ShouldBe("parameter");
+        }
+
+        [Test]
+        public void WhenNotEmpty_Guid_GivenNotEmptyGuid_Then_Value()
+        {
+            // Arrange
+            var value = Guid.NewGuid();
+
+            // Act
+            var actual = value.WhenNotEmpty("parameter");
+
+            // Assert
+            actual.ShouldBe(value);
+        }
     }
 }

--- a/src/Extensions/Validation/WhenNotEmptyExtensionMethod.cs
+++ b/src/Extensions/Validation/WhenNotEmptyExtensionMethod.cs
@@ -32,5 +32,15 @@ namespace AsIfByMagic.Extensions.Validation
 
             return value;
         }
+
+        public static Guid WhenNotEmpty(this Guid value, string paramName)
+        {
+            if(value == Guid.Empty)
+            {
+                throw new ArgumentException("Value cannot be an empty guid.", paramName);
+            }
+
+            return value;
+        }
     }
 }

--- a/src/Extensions/Validation/WhenNotEmptyExtensionMethod.cs
+++ b/src/Extensions/Validation/WhenNotEmptyExtensionMethod.cs
@@ -1,0 +1,22 @@
+using System;
+
+namespace AsIfByMagic.Extensions.Validation
+{
+    public static class WhenNotEmptyExtensionMethod
+    {
+        public static string WhenNotEmpty(this string value, string paramName)
+        {
+            if(value == null)
+            {
+                throw new ArgumentNullException(paramName);
+            }
+
+            if(value == string.Empty)
+            {
+                throw new ArgumentException("Value cannot be an empty string.", paramName);
+            }
+
+            return value;
+        }
+    }
+}

--- a/src/Extensions/Validation/WhenNotEmptyExtensionMethod.cs
+++ b/src/Extensions/Validation/WhenNotEmptyExtensionMethod.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections;
+using System.Linq;
 
 namespace AsIfByMagic.Extensions.Validation
 {
@@ -14,6 +16,18 @@ namespace AsIfByMagic.Extensions.Validation
             if(value == string.Empty)
             {
                 throw new ArgumentException("Value cannot be an empty string.", paramName);
+            }
+
+            return value;
+        }
+
+        public static T WhenNotEmpty<T>(this T value, string paramName) where T : IEnumerable
+        {
+            _ = value.WhenNotNull(nameof(value));
+
+            if(!value.Cast<object>().Any())
+            {
+                throw new ArgumentException("Value cannot be an empty enumerable.", paramName);
             }
 
             return value;

--- a/src/Extensions/Validation/WhenNotNullExtensionMethod.cs
+++ b/src/Extensions/Validation/WhenNotNullExtensionMethod.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace AsIfByMagic.Extensions.Validation
+{
+    public static class WhenNotNullExtensionMethod
+    {
+        public static T WhenNotNull<T>(this T value, string paramName)
+        {
+            // TODO Do we wish to validate there is a paramName? What happens if we pass null or string.Empty to the ctor?
+
+            if(!Equals(value, null))
+            {
+                return value;
+            }
+
+            throw new ArgumentNullException(paramName);
+        }
+    }
+}


### PR DESCRIPTION
This adds an extension method for validating that parameters are not considered "empty". What constitutes empty may vary depending on the type of parameter.

***

Before you submit your pull request please ensure:

- [x] You have recently updated your feature branch from master
- [x] You have annotated your commits with any information that may help reviewers
- [x] You have considered principles such as [GRASP](https://en.wikipedia.org/wiki/GRASP_(object-oriented_design)), and [SOLID](https://en.wikipedia.org/wiki/SOLID)
- [x] You have used appropriate terms for the current domain when naming things
- [x] Your code builds without warnings or errors from either Visual Studio or R#
- [x] You have not left any dead code behind
- [x] You have added appropriate unit and / or integration tests *and they all pass*
- [x] You have set an appropriate version number which follows [SemVer](https://semver.org/)